### PR TITLE
fix: remove Twitter link from blog posts

### DIFF
--- a/src/content/blog/hello-world/en.md
+++ b/src/content/blog/hello-world/en.md
@@ -53,7 +53,6 @@ Stay tuned for upcoming posts where we'll dive deeper into:
 
 We'd love to hear from you! Whether you have questions, feedback, or ideas for future blog posts, feel free to reach out:
 
-- Follow us on [X (Twitter)](https://twitter.com/projecthami)
 - Join our [Slack community](https://cloud-native.slack.com/archives/C07T10BU4R2)
 - Star us on [GitHub](https://github.com/Project-HAMi/HAMi)
 

--- a/src/content/blog/hello-world/zh.md
+++ b/src/content/blog/hello-world/zh.md
@@ -53,7 +53,6 @@ AI 和机器学习的世界正在快速发展，基础设施需求也在不断�
 
 我们很希望听到您的声音！无论您有问题、反馈还是对未来博客文章的想法，请随时联系我们：
 
-- 在 [X (Twitter)](https://twitter.com/projecthami) 上关注我们
 - 加入我们的 [Slack 社区](https://cloud-native.slack.com/archives/C07T10BU4R2)
 - 在 [GitHub](https://github.com/Project-HAMi/HAMi) 上给我们点星
 


### PR DESCRIPTION
- Removed the Twitter follow link from both English and Chinese versions of the "Hello World" blog post to streamline contact options.
- This change aims to focus on community engagement through Slack and GitHub instead.