### PR TITLE
fix:X-Frame-Options may only be set via an HTTP header sent along wit…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
…h a document. It may not be set inside <meta>.